### PR TITLE
Add "failure" handler to route configurations

### DIFF
--- a/RULESENGINE.md
+++ b/RULESENGINE.md
@@ -347,7 +347,8 @@ const routes  = Joi.object().keys({
     httpAction : Joi.string().valid('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
     tags       : Joi.array().items(Joi.string()).min(1).optional(),
     description: Joi.string().optional().allow(null, ''),
-    actions    : Joi.array().items(action, actions).min(1)
+    actions    : Joi.array().items(action, actions).min(1),
+    failure    : Joi.array().items(action, actions).min(1).optional()
 });
 const schema  = Joi.object().keys({
     routes: Joi.array().items(routes).min(1)

--- a/RULESENGINE.md
+++ b/RULESENGINE.md
@@ -6,14 +6,15 @@
 
 - [configuration](#configuration)
   - [routes](#routes)
-  - [route](#route)
+    - [route](#route)
   - [actions](#actions)
-  - [action](#action)
-  - [parallel actions](#parallel-actions)
+    - [action](#action)
+    - [parallel actions](#parallel-actions)
+  - [failure](#failure)
 - [schema](#schema)
-- [how to implement my very own action handler](#how-to-implement-my-very-own-action-handler)
-  - [execution context](#execution-context)
-  - [action handler](#action-handler)
+- [Action Handler Contract](#action-handler-contract)
+  - [Context](#context)
+  - [method](#method)
     - [returning an object](#returning-an-object)
     - [returning a promise](#returning-a-promise)
   - [error handling](#error-handling)
@@ -43,6 +44,12 @@ let's take a look at the different pieces that make a toki configuration.
                  "name": "inventory",
                  "type": "toki-method-inventory-lookup"
              }
+         ],
+         "failure"   : [
+             {
+                 "name": "rollback",
+                 "type": "toki-method-rollback"
+             }
          ]
      }
   ]
@@ -53,7 +60,7 @@ let's take a look at the different pieces that make a toki configuration.
 
 An array of [route](#route) objects.
 
-### route
+#### route
 
  - `url` - partial http url including params in the style of __toki-bridge__ being used.
 
@@ -98,7 +105,7 @@ An array of [route](#route) objects.
 
 ### actions
 
-An array of [action](#action) to be executed in sequential order.
+An array of [action](#action) rules to be executed in sequential order.
 
 
  ```json
@@ -108,33 +115,33 @@ An array of [action](#action) to be executed in sequential order.
          "path"      : "/products/{id}",
          "httpAction": "GET",
          "actions"   : [
-             {                    
+             {
                  "name": "product",
                  "type": "toki-method-product-lookup",
                  "description" : "lookup product catalog"
              },
-             {                    
+             {
                  "name": "inventory",
                  "type": "toki-method-inventory-lookup",
-                 "description" : "lookup product inventory"                 
+                 "description" : "lookup product inventory"
              },
-             {                    
+             {
                  "name": "backorder",
                  "type": "toki-method-product-backorder",
-                 "description" : "check if product inventory is below limit and initiate backorder"                 
+                 "description" : "check if product inventory is below limit and initiate backorder"
              },
-             {                    
+             {
                  "name": "map",
                  "type": "toki-method-product-lookup",
-                 "description" : "compose reponse payload with product description and inventory"                 
-             }                         
+                 "description" : "compose reponse payload with product description and inventory"
+             }
          ]
      }
   ]
 }
  ```
 
-### action
+#### action
 
 - `name` - name of the action to be executed. action name will be used to bind the action response to the execution context, that way subsequent actions will be able to use the previos action response, say what?
  let's take a deep breath and try to explain this nonsense:
@@ -217,7 +224,7 @@ On the previous configuration `toki-method-product-lookup` will be invoked as `r
 
 - `options` - optional. Configuration object to be passed to the action executor.
 
-### parallel actions
+#### parallel actions
 
 if your action is an array of [action](#action) objects, those will be executed in parallel and wait for all actions to finish before continuing with the next action in the execution process.
 
@@ -274,6 +281,54 @@ Clear as mud right? this code example will be crystal clear to our nerdy readers
  2. actions `inventory-central`, `inventory-easr`, `inventory-west` execute in parallel and wait for all 3 actions fo finish execution.
  3. action `backorder` executes.
  4. action `map` executes.
+ 
+### failure
+
+An array of [action](#action) rules to be executed in sequential order. These failure rules are executed if one or more rule from the `"actions"` ruleset error out.
+
+The failure rules are executed identically the same as [action](#action) rules, with the sole exception being that an additional property `errors` is added to the parameter passed to the toki-method handler.
+
+An error in the `"failure"` ruleset will result in a 500 Server Error response being sent.
+
+```json
+{
+ "routes": [
+     {
+         "path"      : "/products/{id}",
+         "httpAction": "GET",
+         "actions"   : [
+             {                    
+                 "name": "product",
+                 "type": "toki-method-product-lookup",
+                 "description" : "lookup product catalog"
+             },
+             {                    
+                 "name": "inventory",
+                 "type": "toki-method-inventory-lookup",
+                 "description" : "lookup product inventory"                 
+             },
+             {                    
+                 "name": "backorder",
+                 "type": "toki-method-product-backorder",
+                 "description" : "check if product inventory is below limit and initiate backorder"                 
+             },
+             {                    
+                 "name": "map",
+                 "type": "toki-method-product-lookup",
+                 "description" : "compose reponse payload with product description and inventory"                 
+             }                         
+         ],
+         "failure"   : [
+             {
+                  "name": "rollback",
+                  "type": "toki-method-rollback",
+                  "description": "roll back any changes triggered in unsuccessful 'actions'"
+             }
+         ]
+     }
+  ]
+}
+ ```
 
 ## schema
 

--- a/lib/internals/configuration.js
+++ b/lib/internals/configuration.js
@@ -23,7 +23,8 @@ const configSchema  = Joi.object().keys({
             httpAction : Joi.string().valid('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
             tags       : Joi.array().items(Joi.string()).min(1).optional(),
             description: Joi.string().optional().allow(null, ''),
-            actions    : Joi.array().items(actionSchema, Joi.array().items(actionSchema).min(2) ).min(1)
+            actions    : Joi.array().items(actionSchema, Joi.array().items(actionSchema).min(2) ).min(1),
+            failure    : Joi.array().items(actionSchema, Joi.array().items(actionSchema).min(2) ).min(1).optional()
         })
     ).min(1)
 }).label('toki configuration');

--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -44,6 +44,12 @@ class RouteHandler {
             response
         };
 
+        const defaultErrorHandler = function (err) {
+
+            Logger.error('Route handler errored', this, err);
+            return response.send(Boom.badImplementation());
+        };
+
         Logger.debug('Route handler starting', this);
 
         return Promise.resolve()
@@ -60,12 +66,16 @@ class RouteHandler {
             })
             .catch((error) => {
 
-                Logger.error('Route handler errored', this, error);
-                response.send(Boom.badImplementation());
+                if (this.config.failure) {
+                    return this.actionsHandler.call(this, this.config.failure, error)
+                        .catch(defaultErrorHandler);
+                }
+
+                return defaultErrorHandler(error);
             });
     }
 
-    actionsHandler(actions) {
+    actionsHandler(actions, ...errors) {
 
         //Create sequential action handlers
         return Promise.mapSeries(actions, (action) => {
@@ -74,21 +84,20 @@ class RouteHandler {
                 .bind(this)
                 .then(() => {
 
-                    return action;
-                })
-                .then(this.actionHandler);
+                    return this.actionHandler.call(this, action, errors);
+                });
         });
     }
 
     /*
      * Execute individual action
      * */
-    actionHandler(action) {
+    actionHandler(action, errors) {
 
         //is it parallel actions
         if (Array.isArray(action)) {
             //exec parallel
-            return this.parallelActionHandler.bind(this)(action);
+            return this.parallelActionHandler.call(this, action, errors);
         }
 
         Logger.debug('Route handler action starting', action, this);
@@ -111,7 +120,8 @@ class RouteHandler {
                 return {
                     action,
                     request : this.server.request,
-                    response: this.server.response
+                    response: this.server.response,
+                    errors
                 };
             })
             .then(handler)
@@ -127,7 +137,7 @@ class RouteHandler {
     /*
      * Execute parallel actions
      * */
-    parallelActionHandler(actions) {
+    parallelActionHandler(actions, errors) {
 
         return Promise.map(actions, (action) => {
 
@@ -136,9 +146,8 @@ class RouteHandler {
                 .bind(this)
                 .then(() => {
 
-                    return action;
-                })
-                .then(this.actionHandler);
+                    return this.actionHandler.call(this, action, errors);
+                });
         })
             .then(() => {
                 //Promise.all returns original array, which there's no need in this case

--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -80,12 +80,7 @@ class RouteHandler {
         //Create sequential action handlers
         return Promise.mapSeries(actions, (action) => {
 
-            return Promise.resolve()
-                .bind(this)
-                .then(() => {
-
-                    return this.actionHandler.call(this, action, errors);
-                });
+            return this.actionHandler.call(this, action, errors);
         });
     }
 
@@ -142,12 +137,7 @@ class RouteHandler {
         return Promise.map(actions, (action) => {
 
             //call actionHandler
-            return Promise.resolve()
-                .bind(this)
-                .then(() => {
-
-                    return this.actionHandler.call(this, action, errors);
-                });
+            return this.actionHandler.call(this, action, errors);
         })
             .then(() => {
                 //Promise.all returns original array, which there's no need in this case


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the `"failure"` handler to route configurations to allow for custom orchestration failure handling.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #13 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Rather than simply sending a 500 Server Error whenever any step in the `"actions"` ruleset is unsuccessful, the `"failure"` configuration allows you to define a ruleset of actions to perform in the case of any unsuccessful `"actions"`. 

The `"failure"` actions are handled exactly the same as `"actions"` rules would be, with the exception that the context parameter passed to them has an additional `errors` property. The value is an array of errors from the failed `"actions"` steps.

In the case that a rule in `"failure"` errors out, the default 500 Server Error response will be sent.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
