### PR TITLE
Add built in http responder

### DIFF
--- a/lib/internals/index.js
+++ b/lib/internals/index.js
@@ -3,6 +3,7 @@
 module.exports = {
     configuration: require('./configuration'),
     options      : require('./options'),
+    responder    : require('./responder'),
     routeBuilder : require('./routeBuilder'),
     routeHandler : require('./routeHandler')
 };

--- a/lib/internals/responder.js
+++ b/lib/internals/responder.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const Joi = require('joi');
+const Templater = require('toki-templater');
+
+const responderConfigSchema = Joi.object().keys({
+    statusCode: Joi.alternatives().try([
+        Joi.string(),
+        Joi.number()
+    ]).required(),
+    payload: Joi.alternatives().try([
+        Joi.string(),
+        Joi.object()
+    ]).optional()
+});
+
+module.exports = function () {
+
+    const self = this;
+
+    if (!self.config.clientResponse) {
+        throw new Error('responder action configuration must include response mapping configs');
+    }
+
+    const validConfig = responderConfigSchema.validate(self.config.clientResponse);
+
+    if (validConfig.error) {
+        throw validConfig.error;
+    }
+
+    return Templater(self.config.clientResponse, null, {
+        context: self.contexts
+    })
+        .then((responseData) => {
+
+            self.server.response.code(parseInt(responseData.statusCode));
+
+            return responseData.payload ?
+                self.server.response.send(responseData.payload) :
+                self.server.response.send();
+        });
+};

--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -38,7 +38,7 @@ class RouteHandler {
      * */
     handle(request, response) {
 
-        //create bounde context
+        //create bounded context
         this.server = {
             request,
             response
@@ -98,7 +98,14 @@ class RouteHandler {
         Logger.debug('Route handler action starting', action, this);
 
         //require handler to be called as per configuration type
-        const handler = require(action.type);
+        let handler;
+
+        if (action.type === 'responder') {
+            handler = require('./responder');
+        }
+        else {
+            handler = require(action.type);
+        }
 
         this.contexts[action.name] = {
             server  : this.server,

--- a/package.json
+++ b/package.json
@@ -23,17 +23,18 @@
     "toki-logger": "1.x.x"
   },
   "dependencies": {
-    "bluebird": "^3.4.7",
-    "boom": "^4.2.0",
-    "joi": "10.x"
+    "bluebird": "3.4.x",
+    "boom": "4.2.x",
+    "joi": "10.x",
+    "toki-templater": "1.x.x"
   },
   "devDependencies": {
     "code": "4.x",
-    "doctoc": "^1.2.0",
+    "doctoc": "1.x",
     "lab": "12.x",
-    "proxyquire": "^1.7.11",
-    "sinon": "^1.17.7",
-    "toki-config": "0.x.x",
-    "toki-logger": "1.x.x"
+    "proxyquire": "1.7.x",
+    "sinon": "1.17.x",
+    "toki-config": "0.x",
+    "toki-logger": "1.x"
   }
 }

--- a/test/internals/responder.js
+++ b/test/internals/responder.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const Sinon  = require('sinon');
+const Promise = require('bluebird');
+const Lab = require('lab');
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const beforeEach = lab.beforeEach;
+
+const Code   = require('code');
+const expect = Code.expect;
+
+const Responder = require('../../lib/internals/responder');
+
+describe('Responder', () => {
+
+    const responseSpy = {
+        code: Sinon.spy(),
+        send: Sinon.spy()
+    };
+
+    beforeEach((done) => {
+
+        responseSpy.code.reset();
+        responseSpy.send.reset();
+        done();
+    });
+
+    it('should fail if the action config does not contain "clientResponse"', (done) => {
+
+        expect(Responder.bind({
+            config: {}
+        }, {})).to.throw('responder action configuration must include response mapping configs');
+        done();
+    });
+
+    it('should fail if the action clientResponse config does not contain "statusCode"', (done) => {
+
+        const context = {
+            config: {
+                clientResponse: {}
+            }
+        };
+
+        expect(Responder.bind(context, {})).to.throw('child "statusCode" fails because ["statusCode" is required]');
+        done();
+    });
+
+    it('should fail if the action clientResponse.statusCode is not a number or string', (done) => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: true
+                }
+            }
+        };
+
+        expect(Responder.bind(context, {})).to.throw('child "statusCode" fails because ["statusCode" must be a string, "statusCode" must be a number]');
+        done();
+    });
+
+    it('should fail if the action clientResponse.payload is not an object or string', (done) => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: 201,
+                    payload   : 201
+                }
+            }
+        };
+
+        expect(Responder.bind(context, {})).to.throw('child "payload" fails because ["payload" must be a string, "payload" must be an object]');
+        done();
+    });
+
+    it('should send the response with the given statusCode', () => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: 200
+                }
+            },
+            server: {
+                response: responseSpy
+            }
+        };
+
+        return Promise
+            .resolve()
+            .bind(context)
+            .then(Responder)
+            .then(() => {
+
+                expect(responseSpy.send.calledOnce).to.be.true();
+                expect(responseSpy.code.calledOnce).to.be.true();
+                expect(responseSpy.code.calledWith(200)).to.be.true();
+            });
+    });
+
+    it('should send the response with the given statusCode and payload', () => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: 200,
+                    payload   : {
+                        send: 'this data'
+                    }
+                }
+            },
+            server: {
+                response: responseSpy
+            }
+        };
+
+        return Promise
+            .resolve()
+            .bind(context)
+            .then(Responder)
+            .then(() => {
+
+                expect(responseSpy.send.calledOnce).to.be.true();
+                expect(responseSpy.send.calledWith(context.config.clientResponse.payload)).to.be.true();
+                expect(responseSpy.code.calledOnce).to.be.true();
+                expect(responseSpy.code.calledWith(200)).to.be.true();
+            });
+    });
+
+    it('should support templated clientResponse.statusCode string', () => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: '{{previousStep.output.code}}'
+                }
+            },
+            server: {
+                response: responseSpy
+            },
+            contexts: {
+                previousStep: {
+                    output: {
+                        code: 201
+                    }
+                }
+            }
+        };
+
+        return Promise
+            .resolve()
+            .bind(context)
+            .then(Responder)
+            .then(() => {
+
+                expect(responseSpy.send.calledOnce).to.be.true();
+                expect(responseSpy.code.calledOnce).to.be.true();
+                expect(responseSpy.code.calledWith(201)).to.be.true();
+            });
+    });
+
+    it('should support templated clientResponse.payload string', () => {
+
+        const context = {
+            config: {
+                clientResponse: {
+                    statusCode: '{{previousStep.output.code}}',
+                    payload   : '{{previousStep.output}}'
+                }
+            },
+            server: {
+                response: responseSpy
+            },
+            contexts: {
+                previousStep: {
+                    output: {
+                        code: 201,
+                        data: 'to send'
+                    }
+                }
+            }
+        };
+
+        return Promise
+            .resolve()
+            .bind(context)
+            .then(Responder)
+            .then(() => {
+
+                expect(responseSpy.send.calledOnce).to.be.true();
+                expect(responseSpy.send.calledWith(context.contexts.previousStep.output)).to.be.true();
+                expect(responseSpy.code.calledOnce).to.be.true();
+                expect(responseSpy.code.calledWith(201)).to.be.true();
+            });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows for http responses to be sent back in isolation.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #16 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows for more granular response delegation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
