### PR TITLE
Rename clientResponse to clientResponseConfiguration

### DIFF
--- a/lib/internals/responder.js
+++ b/lib/internals/responder.js
@@ -18,17 +18,17 @@ module.exports = function () {
 
     const self = this;
 
-    if (!self.config.clientResponse) {
+    if (!self.config.clientResponseConfiguration) {
         throw new Error('responder action configuration must include response mapping configs');
     }
 
-    const validConfig = responderConfigSchema.validate(self.config.clientResponse);
+    const validConfig = responderConfigSchema.validate(self.config.clientResponseConfiguration);
 
     if (validConfig.error) {
         throw validConfig.error;
     }
 
-    return Templater(self.config.clientResponse, null, {
+    return Templater(self.config.clientResponseConfiguration, null, {
         context: self.contexts
     })
         .then((responseData) => {

--- a/test/internals/responder.js
+++ b/test/internals/responder.js
@@ -27,7 +27,7 @@ describe('Responder', () => {
         done();
     });
 
-    it('should fail if the action config does not contain "clientResponse"', (done) => {
+    it('should fail if the action config does not contain "clientResponseConfiguration"', (done) => {
 
         expect(Responder.bind({
             config: {}
@@ -35,11 +35,11 @@ describe('Responder', () => {
         done();
     });
 
-    it('should fail if the action clientResponse config does not contain "statusCode"', (done) => {
+    it('should fail if the action clientResponseConfiguration config does not contain "statusCode"', (done) => {
 
         const context = {
             config: {
-                clientResponse: {}
+                clientResponseConfiguration: {}
             }
         };
 
@@ -47,11 +47,11 @@ describe('Responder', () => {
         done();
     });
 
-    it('should fail if the action clientResponse.statusCode is not a number or string', (done) => {
+    it('should fail if the action clientResponseConfiguration.statusCode is not a number or string', (done) => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: true
                 }
             }
@@ -61,11 +61,11 @@ describe('Responder', () => {
         done();
     });
 
-    it('should fail if the action clientResponse.payload is not an object or string', (done) => {
+    it('should fail if the action clientResponseConfiguration.payload is not an object or string', (done) => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: 201,
                     payload   : 201
                 }
@@ -80,7 +80,7 @@ describe('Responder', () => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: 200
                 }
             },
@@ -105,7 +105,7 @@ describe('Responder', () => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: 200,
                     payload   : {
                         send: 'this data'
@@ -124,17 +124,17 @@ describe('Responder', () => {
             .then(() => {
 
                 expect(responseSpy.send.calledOnce).to.be.true();
-                expect(responseSpy.send.calledWith(context.config.clientResponse.payload)).to.be.true();
+                expect(responseSpy.send.calledWith(context.config.clientResponseConfiguration.payload)).to.be.true();
                 expect(responseSpy.code.calledOnce).to.be.true();
                 expect(responseSpy.code.calledWith(200)).to.be.true();
             });
     });
 
-    it('should support templated clientResponse.statusCode string', () => {
+    it('should support templated clientResponseConfiguration.statusCode string', () => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: '{{previousStep.output.code}}'
                 }
             },
@@ -162,11 +162,11 @@ describe('Responder', () => {
             });
     });
 
-    it('should support templated clientResponse.payload string', () => {
+    it('should support templated clientResponseConfiguration.payload string', () => {
 
         const context = {
             config: {
-                clientResponse: {
+                clientResponseConfiguration: {
                     statusCode: '{{previousStep.output.code}}',
                     payload   : '{{previousStep.output}}'
                 }

--- a/test/toki.js
+++ b/test/toki.js
@@ -1633,7 +1633,7 @@ describe('toki', () => {
             };
             httpSpy();
 
-            if (actionContext.action.clientResponse) {
+            if (actionContext.action.clientResponseConfiguration) {
                 if (actionContext.request.failThis) {
                     if (actionContext.action.name === 'failure1') {
                         // successful handling in "failure" to send error response back to client
@@ -1702,7 +1702,7 @@ describe('toki', () => {
                             {
                                 name          : 'action1',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             }
@@ -1797,7 +1797,7 @@ describe('toki', () => {
                             {
                                 name: 'action2',
                                 type: 'responder',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     statusCode: 200,
                                     payload: {
                                         success: true,
@@ -1893,7 +1893,7 @@ describe('toki', () => {
                             {
                                 name          : 'action1',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },
@@ -1996,7 +1996,7 @@ describe('toki', () => {
                             {
                                 name          : 'action2',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },
@@ -2099,7 +2099,7 @@ describe('toki', () => {
                             {
                                 name          : 'action2',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },
@@ -2202,7 +2202,7 @@ describe('toki', () => {
                                 {
                                     name          : 'action2',
                                     type          : 'method-http',
-                                    clientResponse: {
+                                    clientResponseConfiguration: {
                                         sendIt: true
                                     }
                                 }
@@ -2305,7 +2305,7 @@ describe('toki', () => {
                             {
                                 name          : 'action2',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },
@@ -2318,7 +2318,7 @@ describe('toki', () => {
                             {
                                 name          : 'failure1',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },
@@ -2421,7 +2421,7 @@ describe('toki', () => {
                                 {
                                     name          : 'action2',
                                     type          : 'method-http',
-                                    clientResponse: {
+                                    clientResponseConfiguration: {
                                         sendIt: true
                                     }
                                 }
@@ -2435,7 +2435,7 @@ describe('toki', () => {
                             {
                                 name          : 'failure1',
                                 type          : 'method-http',
-                                clientResponse: {
+                                clientResponseConfiguration: {
                                     sendIt: true
                                 }
                             },


### PR DESCRIPTION
Cleaning up config naming for consistency.

Closes #18 