### PR TITLE
Adds "errors" to this.contexts for methods

### DIFF
--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -112,7 +112,8 @@ class RouteHandler {
             Promise : this.Promise,
             Logger,
             config  : action,
-            contexts: this.contexts
+            contexts: this.contexts,
+            errors
         };
 
         return Promise.resolve()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds `errors` to the contexts passed to methods.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
n/a

## Motivation and Context
This removes the need for errors to be passed through the (currently-unused) method parameters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] All new and existing tests passed.
