### PR TITLE
Standardize method param

### DIFF
--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -115,7 +115,9 @@ class RouteHandler {
             server  : this.server,
             Promise : this.Promise,
             Logger,
+            errors,
             config  : action,
+            action,
             contexts: this.contexts
         };
 
@@ -123,12 +125,7 @@ class RouteHandler {
             .bind(this.contexts[action.name])
             .then(() => {
 
-                return {
-                    action,
-                    request : this.server.request,
-                    response: this.server.response,
-                    errors
-                };
+                return this.contexts[action.name];
             })
             .then(handler)
             .then((output) => {

--- a/test/internals/routeHandler.js
+++ b/test/internals/routeHandler.js
@@ -63,7 +63,7 @@ describe('route handler tests', () => {
             'action-handler1': (input) => {
 
                 action1Spy();
-                input.response.send();
+                input.server.response.send();
                 return {
                     key: 'value1'
                 };
@@ -71,7 +71,7 @@ describe('route handler tests', () => {
             'action-handler2': (input) => {
 
                 action2Spy();
-                input.response.send();
+                input.server.response.send();
                 return {
                     key: 'value2'
                 };
@@ -79,7 +79,7 @@ describe('route handler tests', () => {
             'action-handler3': (input) => {
 
                 action3Spy();
-                input.response.send();
+                input.server.response.send();
                 return {
                     key: 'value3'
                 };
@@ -87,7 +87,7 @@ describe('route handler tests', () => {
             'action-handler4': (input) => {
 
                 action4Spy();
-                input.response.send();
+                input.server.response.send();
                 return {
                     key: 'value4'
                 };
@@ -96,9 +96,9 @@ describe('route handler tests', () => {
 
                 actionPromiseSpy();
 
-                return new this.Promise((resolve, reject) => {
+                return new input.Promise((resolve, reject) => {
 
-                    input.response.send();
+                    input.server.response.send();
                     return resolve();
                 });
             }
@@ -247,7 +247,7 @@ describe('route handler tests', () => {
             'action-handler1': (input) => {
 
                 action1Spy();
-                input.response.send();
+                input.server.response.send();
                 return {
                     key1: 'value1'
                 };
@@ -255,7 +255,7 @@ describe('route handler tests', () => {
             'action-handler2': function(input) {
 
                 action2Spy();
-                input.response.send();
+                input.server.response.send();
 
                 return Object.assign({
                     key2: 'value2'
@@ -264,7 +264,7 @@ describe('route handler tests', () => {
             'action-handler3': function(input) {
 
                 action3Spy();
-                input.response.send();
+                input.server.response.send();
 
                 return Object.assign({
                     key3: 'value3'

--- a/test/toki.js
+++ b/test/toki.js
@@ -325,7 +325,7 @@ describe('toki', () => {
 
                 action3Spy();
                 const response = this.contexts.action2.output;
-                args.response.send(response);
+                args.server.response.send(response);
             },
             'action-handler4': function(args) {
 
@@ -345,7 +345,7 @@ describe('toki', () => {
 
                 action6Spy();
                 const response = this.contexts.action5.output;
-                args.response.send(response);
+                args.server.response.send(response);
             }
         };
         const LoggerProxy = {
@@ -504,7 +504,7 @@ describe('toki', () => {
 
                 action3Spy();
                 const response = Object.assign({}, this.contexts.action1.output, this.contexts.action2.output);
-                args.response.send(response);
+                args.server.response.send(response);
             },
             'action-handler4': function(args) {
 
@@ -524,7 +524,7 @@ describe('toki', () => {
 
                 action6Spy();
                 const response = Object.assign({}, this.contexts.action4.output, this.contexts.action5.output);
-                args.response.send(response);
+                args.server.response.send(response);
             }
         };
         const LoggerProxy = {
@@ -693,7 +693,7 @@ describe('toki', () => {
 
                 action3Spy();
                 const response = Object.assign({}, this.contexts.action1.output, this.contexts.action2.output);
-                args.response.send(response);
+                args.server.response.send(response);
             },
             'action-handler4': function(args) {
 
@@ -718,7 +718,7 @@ describe('toki', () => {
 
                 failureSpy(args.errors);
                 const response = Boom.badRequest();
-                args.response.send(response);
+                args.server.response.send(response);
             }
         };
         const LoggerProxy = {
@@ -894,7 +894,7 @@ describe('toki', () => {
 
                 action3Spy();
                 const response = Object.assign({}, this.contexts.action1.output, this.contexts.action2.output);
-                args.response.send(response);
+                args.server.response.send(response);
             },
             'action-handler4': function(args) {
 
@@ -919,7 +919,7 @@ describe('toki', () => {
 
                 failureSpy(args.errors);
                 const response = Boom.badRequest();
-                args.response.send(response);
+                args.server.response.send(response);
             }
         };
         const LoggerProxy = {
@@ -1099,7 +1099,7 @@ describe('toki', () => {
 
                 action3Spy();
                 const response = Object.assign({}, this.contexts.action1.output, this.contexts.action2.output);
-                args.response.send(response);
+                args.server.response.send(response);
             },
             'action-handler4': function(args) {
 
@@ -1124,7 +1124,7 @@ describe('toki', () => {
 
                 failureSpy(args.errors);
                 const response = Boom.badRequest();
-                args.response.send(response);
+                args.server.response.send(response);
             }
         };
         const LoggerProxy = {
@@ -1443,7 +1443,7 @@ describe('toki', () => {
             'action-handler3': function(args) {
 
                 action3Spy();
-                args.response.send(this.action2);
+                args.server.response.send(this.action2);
             }
         };
         const LoggerProxy = {
@@ -1634,17 +1634,17 @@ describe('toki', () => {
             httpSpy();
 
             if (actionContext.action.clientResponseConfiguration) {
-                if (actionContext.request.failThis) {
+                if (actionContext.server.request.failThis) {
                     if (actionContext.action.name === 'failure1') {
                         // successful handling in "failure" to send error response back to client
-                        return actionContext.response.send(Boom.badRequest());
+                        return actionContext.server.response.send(Boom.badRequest());
                     }
                     // method failure in "actions"
                     throw new Error('Failed out the http handler on purpose');
                 }
                 else {
                     // successful handling in "actions" to send response back to client
-                    return actionContext.response.send(result);
+                    return actionContext.server.response.send(result);
                 }
             }
             else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously the input parameters to methods was a weird hodge-podge which didn't follow the same layout as context. This PR changes the method param to be a pointer to an actions context.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Documentation only (no changes to either `lib/` or `test/` files)
- [ ] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)
- [ ] New feature (non-breaking change which adds functionality. you added at least one new test)
- [x] Breaking change (fix or feature that would cause existing functionality to change. you had to modify existing tests.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
