### PR TITLE
Use Hoek.clone to prevent shared context between requests

### DIFF
--- a/lib/internals/responder.js
+++ b/lib/internals/responder.js
@@ -29,7 +29,7 @@ module.exports = function () {
     }
 
     return Templater(self.config.clientResponseConfiguration, null, {
-        context: self.contexts
+        hydrationContext: self.contexts
     })
         .then((responseData) => {
 

--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird');
 const Boom    = require('boom');
+const Hoek    = require('hoek');
 const Logger  = require('toki-logger')();
 
 /*
@@ -38,8 +39,10 @@ class RouteHandler {
      * */
     handle(request, response) {
 
+        const context = Hoek.clone(this);
+
         //create bounded context
-        this.server = {
+        context.server = {
             request,
             response
         };
@@ -53,8 +56,8 @@ class RouteHandler {
         Logger.debug('Route handler starting', this);
 
         return Promise.resolve()
-            .bind(this)
-            .then(() => {
+            .bind(context)
+            .then(function () {
 
                 return this.config.actions;
             })
@@ -62,9 +65,8 @@ class RouteHandler {
             .then(() => {
 
                 Logger.debug('Route handler finished', this);
-                response.end();
             })
-            .catch((error) => {
+            .catch(function (error) {
 
                 if (this.config.failure) {
                     return this.actionsHandler.call(this, this.config.failure, error)

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "dependencies": {
     "bluebird": "3.4.x",
     "boom": "4.2.x",
+    "hoek": "4.x",
     "joi": "10.x",
-    "toki-templater": "1.x.x"
+    "toki-templater": "2.x.x"
   },
   "devDependencies": {
     "code": "4.x",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR accomplishes 3 things:
  1. Updates toki-logger used in `internals.responder` to v2.x
  2. Removes extraneous `response.end()` call in `internals.routeHandler` that resulted in duplicate `response.send()` calls throwing errors with `toki-hapi-bridge` when the response is delegated to a method.
  3. Implements `Hoek.clone(this)` for the routeHandler context to prevent context bleed between requests.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
none

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. Breaking change in `toki-templater`
2. Response delegation via `clientResponseConfiguration` in `internals.responder` resulted in Hapi errors when used with `toki-hapi-bridge`
3. Subsequent requests to the same endpoint began with the ending context of the previous request. (Note: because of how the Toki tests are set up, I could not figure out a way to replicate this situation inside of unit tests)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue. you didn't modify existing tests)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
