### PR TITLE
Add enumerable "msg" property to handler errors

### DIFF
--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -110,6 +110,12 @@ class RouteHandler {
         }
 
         if (errors.length) {
+            errors = errors.map((err) => {
+
+                err.msg = err.toString();
+
+                return err;
+            });
             this.contexts.errors = errors;
         }
 

--- a/lib/internals/routeHandler.js
+++ b/lib/internals/routeHandler.js
@@ -112,7 +112,10 @@ class RouteHandler {
         if (errors.length) {
             errors = errors.map((err) => {
 
-                err.msg = err.toString();
+                if (err instanceof Error) {
+                    err.errorMessage = err.message;
+                    err.stackTrace = err.stack;
+                }
 
                 return err;
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If native Node.js errors are thrown in the course of an action handler, it would be helpful in debugging to add an enumerable version of the error message.

```js
const err = new Error('ay no');
JSON.stringify(err);
// '{}'
err.msg = err.toString();
JSON.stringify(err);
// '{"msg":"Error: ay no"}'
```

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Useful for debugging.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality. you added at least one new test)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/xogroup/toki/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the [Hapi.js style guide](https://github.com/hapijs/contrib/blob/master/Style.md).
- [x] I have updated the documentation as needed.
- [x] All new and existing tests passed.
